### PR TITLE
Correct some Baja facts, fix bullet point CSS

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -334,7 +334,8 @@ body > .container {
 }
 
 .car > ul {
-  text-align: center;
+  display: inline-block;
+  text-align: left;
   font-size: 14pt;
 }
 
@@ -356,4 +357,5 @@ body > .container {
 
 .car {
   margin-bottom: 40px;
+  text-align:center;
 }

--- a/our_cars.html
+++ b/our_cars.html
@@ -1190,7 +1190,7 @@ order: 3
       </div>
       <ul>
         <li>Front double wishbone, rear trailing link suspension</li>
-        <li>Gaged Engineering GX9 CVT, single inboard rear brake</li>
+        <li>Gaged Engineering GX9 CVT, custom CNC gearbox, single inboard rear brake</li>
         <li>Finished 25th at 2013 Baja SAE Washington competition (WWU hosted the competition)</li>
       </ul>
     </div>
@@ -1227,7 +1227,7 @@ order: 3
       </div>
       <ul>
         <li>Front double wishbone, rear trailing link suspension</li>
-        <li>CVTech CVT, single inboard rear brake</li>
+        <li>CVTech CVT, custom CNC gearbox, single inboard rear brake</li>
         <li>Finished 49th at 2015 Baja SAE Oregon competition</li>
         <li>Finished 43rd at 2016 Baja SAE California competition</li>
       </ul>

--- a/our_cars.html
+++ b/our_cars.html
@@ -865,7 +865,7 @@ order: 3
         </a>
       </div>
       <ul>
-        <li>CVT, custom stressed double-reduction gearbox</li>
+        <li>Comet CVT, custom stressed double reduction gearbox</li>
         <li>Double wishbone suspension</li>
         <li>Driveshaft acts as the rear lower control arm</li>
         <li>Finished 44th at 2002 SAE Midwest Mini-Baja competition</li>
@@ -903,7 +903,7 @@ order: 3
         </a>
       </div>
       <ul>
-        <li>Comet CVT, custom stressed double-reduction gearbox, single inboard rear brake</li>
+        <li>Comet CVT, custom stressed double reduction gearbox, single inboard rear brake</li>
         <li>Custom rack-and-pinion steering</li>
         <li>Finished 42nd at 2003 SAE West Mini-Baja competition</li>
         <li>Finished 13rd at 2004 SAE West Mini-Baja competition</li>
@@ -1190,7 +1190,7 @@ order: 3
       </div>
       <ul>
         <li>Front double wishbone, rear trailing link suspension</li>
-        <li>Gaged Engineering GX9 CVT, custom two-speed gearbox with reverse, single inboard rear brake</li>
+        <li>Gaged Engineering GX9 CVT, single inboard rear brake</li>
         <li>Finished 25th at 2013 Baja SAE Washington competition (WWU hosted the competition)</li>
       </ul>
     </div>
@@ -1227,7 +1227,7 @@ order: 3
       </div>
       <ul>
         <li>Front double wishbone, rear trailing link suspension</li>
-        <li>Gaged Engineering GX9 CVT, custom two-speed gearbox with reverse, single inboard rear brake</li>
+        <li>CVTech CVT, single inboard rear brake</li>
         <li>Finished 49th at 2015 Baja SAE Oregon competition</li>
         <li>Finished 43rd at 2016 Baja SAE California competition</li>
       </ul>


### PR DESCRIPTION
I noticed a couple of minor errors with the Baja cars (I was probably the one who screwed it up originally lol), so I figured I'd submit a pull request to fix them. While I was at it I also messed with the CSS for bullet point lists, so that the bullet points line up with the text.

Here's the way the bullet points are currently formatted:
![image](https://user-images.githubusercontent.com/36322869/222880481-53bacdf4-1eed-4c6b-8e41-f46fbdafcf0e.png)

Here's the proposed formatting:
![image](https://user-images.githubusercontent.com/36322869/222880471-4c60bdfc-17a5-4a31-a8f4-8e3c50378f23.png)
